### PR TITLE
chore: promote jxquickstart2 to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jxquickstart/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jxquickstart'
+  name: jxquickstart
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jxquickstart
+                port:
+                  number: 80
+      host: jxquickstart-jx-staging.change.me

--- a/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-jxquickstart-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-jxquickstart-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: jxquickstart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jxquickstart-jxquickstart
+  labels:
+    draft: draft-app
+    chart: "jxquickstart-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jxquickstart'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jxquickstart-jxquickstart
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jxquickstart-jxquickstart
+    spec:
+      serviceAccountName: jxquickstart-jxquickstart
+      containers:
+        - name: jxquickstart
+          image: "ghcr.io/turbinefish/jxquickstart:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-jxquickstart-sa.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-jxquickstart-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jxquickstart/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jxquickstart-jxquickstart
+  annotations:
+    meta.helm.sh/release-name: 'jxquickstart'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-svc.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart/jxquickstart-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jxquickstart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jxquickstart
+  labels:
+    chart: "jxquickstart-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jxquickstart'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jxquickstart-jxquickstart

--- a/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jxquickstart2/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jxquickstart2'
+  name: jxquickstart2
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jxquickstart2
+                port:
+                  number: 80
+      host: jxquickstart2-jx-staging.change.me

--- a/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-jxquickstart2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-jxquickstart2-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: jxquickstart2/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jxquickstart2-jxquickstart2
+  labels:
+    draft: draft-app
+    chart: "jxquickstart2-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jxquickstart2'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jxquickstart2-jxquickstart2
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jxquickstart2-jxquickstart2
+    spec:
+      serviceAccountName: jxquickstart2-jxquickstart2
+      containers:
+        - name: jxquickstart2
+          image: "ghcr.io/turbinefish/jxquickstart2:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-jxquickstart2-sa.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-jxquickstart2-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jxquickstart2/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jxquickstart2-jxquickstart2
+  annotations:
+    meta.helm.sh/release-name: 'jxquickstart2'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-svc.yaml
+++ b/config-root/namespaces/jx-staging/jxquickstart2/jxquickstart2-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jxquickstart2/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jxquickstart2
+  labels:
+    chart: "jxquickstart2-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jxquickstart2'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jxquickstart2-jxquickstart2

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,21 @@
 	      <td></td>
 	      <td></td>
 	    </tr>
+    <tr>
+		      <td colspan='4'><h3>jx-staging</h3></td>
+		    </tr>
+	    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jxquickstart </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jxquickstart2 </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -223,3 +223,28 @@
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-production/jxquickstart
     version: 0.0.1
+- namespace: jx-staging
+  path: helmfiles/jx-staging/helmfile.yaml
+  releases:
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-12-14T07:06:53Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2021-12-14T07:06:53Z"
+    name: jxquickstart
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-staging/jxquickstart
+    version: 0.0.1
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-12-14T07:06:58Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2021-12-14T07:06:58Z"
+    name: jxquickstart2
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-staging/jxquickstart2
+    version: 0.0.1

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -5,5 +5,6 @@ helmfiles:
 - path: helmfiles/nginx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-production/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: jxquickstart
   values:
   - jx-values.yaml
+- chart: dev/jxquickstart2
+  version: 0.0.1
+  name: jxquickstart2
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/jxquickstart2
   version: 0.0.1
   name: jxquickstart2
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jxquickstart2 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
